### PR TITLE
Handle chained licenses in content_head

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,11 +40,3 @@ repos:
         entry: tox
         language: system
         pass_filenames: false
-
-  - repo: local
-    hooks:
-      - id: only-module-imports
-        name: only-module-imports
-        entry: tox run -e only_module_imports --
-        language: system
-        types: [python]

--- a/src/custom_hooks/copyright_checker.py
+++ b/src/custom_hooks/copyright_checker.py
@@ -130,10 +130,13 @@ def content_head(content: str) -> str:
     """
     Return the head of the content where the copyright should be.
     """
-    # Keep the first six lines to allow for both shebang and encoding
-    # and some leeway for empty lines
-    lines_to_keep = 6
-    head = content.splitlines()[:lines_to_keep]
+    head = []
+    for line in content.splitlines():
+        if line and re.match("[A-Za-z]{1}", line[0]):
+            # This is the first line of code or docstring in file
+            # since it doesn't start with comment or space
+            break
+        head.append(line)
     return "\n".join(head)
 
 

--- a/src/custom_hooks/copyright_checker.py
+++ b/src/custom_hooks/copyright_checker.py
@@ -133,8 +133,11 @@ def content_head(content: str) -> str:
     head = []
     for line in content.splitlines():
         if line and re.match("[A-Za-z]{1}", line[0]):
-            # This is the first line of code or docstring in file
-            # since it doesn't start with comment or space
+            # We consider the first line of "code" to be the first line
+            # with a leading character in the alphabet. We are loose
+            # about this definition to ensure "head" is broad enough
+            # without having to actually determine if a line is code or not
+            # with full certainty.
             break
         head.append(line)
     return "\n".join(head)

--- a/test/test_copyright_checker.py
+++ b/test/test_copyright_checker.py
@@ -250,34 +250,34 @@ def test_chained_licenses_in_java_current_copyright(capsys, tmpdir):
     year = str(datetime.date.today().year)
     f.write(
         f"""
-        /*! ****************************************************************************
-         *
-         * Other company
-         *
-         * Copyright (C) 2002-2017 by other
-         *
-         *******************************************************************************
-         *
-         * Licensed under the Apache License, Version 2.0 (the "License");
-         * you may not use this file except in compliance with
-         * the License. You may obtain a copy of the License at
-         *
-         *    http://www.apache.org/licenses/LICENSE-2.0
-         *
-         * Unless required by applicable law or agreed to in writing, software
-         * distributed under the License is distributed on an "AS IS" BASIS,
-         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-         * See the License for the specific language governing permissions and
-         * limitations under the License.
-         *
-         ******************************************************************************/
+/*! ****************************************************************************
+ *
+ * Other company
+ *
+ * Copyright (C) 2002-2017 by other
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
-        /**
-         * Copyright (c) 2016, {year} by fake. All rights reserved.
-         */
-        package something;
+/**
+ * Copyright (c) 2016, {year} by fake. All rights reserved.
+ */
+package something;
 
-        import java.io.something;
+import java.io.something;
         """
     )
     assert copyright_checker.main(["-o", "fake", f"{f}"]) == 0


### PR DESCRIPTION
I have seen some chained licenses in the wild. Need to handle those gracefully instead of failing since the copyright is not within the first 6 lines of a file.

Instead, we come up with the heuristic that the "head" of the file is anything preceding the first line of "code" (loosely defined as the first line with leading alphabet character).

Bonus: Remove only-module-import check while I investigate some github action issue.