### PR TITLE
Handle .gitignore files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "custom_hooks"
-version = "1.0.0"
+version = "1.0.1"
 description = "Custom pre-commit hooks"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/custom_hooks/copyright_checker.py
+++ b/src/custom_hooks/copyright_checker.py
@@ -31,6 +31,7 @@ HASH_ENDINGS = {
     "toml",
     "yaml",
     "yml",
+    ".gitignore",
 }
 
 DASH_ENDINGS = {"lua"}


### PR DESCRIPTION
# Problem

`.gitignore` files support comments in the same way that other configuration files do

# Solution

Add them to the HASH endings list