### PR TITLE
search_parent_directories=True and absolute path for checking copyright files

### DIFF
--- a/src/custom_hooks/copyright_checker.py
+++ b/src/custom_hooks/copyright_checker.py
@@ -209,7 +209,6 @@ def copyright_checker(filenames: list[str], owner: str, update: bool) -> int:
     for filename in filenames:
         abs_filename = os.path.abspath(filename)
         result = check_copyright(abs_filename, owner, update, repo, year) or result
-
     return result
 
 

--- a/src/custom_hooks/copyright_checker.py
+++ b/src/custom_hooks/copyright_checker.py
@@ -204,7 +204,7 @@ def copyright_checker(filenames: list[str], owner: str, update: bool) -> int:
     Run copyright check on each file.
     """
     result = 0
-    repo = git.Repo(os.getenv("GIT_REPO_DIR", "."))
+    repo = git.Repo(".", search_parent_directories=True)
     year = str(datetime.date.today().year)
     for filename in filenames:
         abs_filename = os.path.abspath(filename)

--- a/src/custom_hooks/copyright_checker.py
+++ b/src/custom_hooks/copyright_checker.py
@@ -204,10 +204,13 @@ def copyright_checker(filenames: list[str], owner: str, update: bool) -> int:
     Run copyright check on each file.
     """
     result = 0
-    repo = git.Repo(".")
+    repo = git.Repo(os.getenv("GIT_REPO_DIR", "."))
     year = str(datetime.date.today().year)
     for filename in filenames:
-        result = check_copyright(filename, owner, update, repo, year) or result
+        abs_filename = os.path.abspath(filename)
+        result = check_copyright(abs_filename, owner, update, repo,
+                                 year) or result
+
     return result
 
 

--- a/src/custom_hooks/copyright_checker.py
+++ b/src/custom_hooks/copyright_checker.py
@@ -209,7 +209,6 @@ def copyright_checker(filenames: list[str], owner: str, update: bool) -> int:
     for filename in filenames:
         abs_filename = os.path.abspath(filename)
         result = check_copyright(abs_filename, owner, update, repo, year) or result
-                                 year) or result
 
     return result
 

--- a/src/custom_hooks/copyright_checker.py
+++ b/src/custom_hooks/copyright_checker.py
@@ -208,7 +208,7 @@ def copyright_checker(filenames: list[str], owner: str, update: bool) -> int:
     year = str(datetime.date.today().year)
     for filename in filenames:
         abs_filename = os.path.abspath(filename)
-        result = check_copyright(abs_filename, owner, update, repo,
+        result = check_copyright(abs_filename, owner, update, repo, year) or result
                                  year) or result
 
     return result


### PR DESCRIPTION
# Problem

We are using hyperscale masking repository to store code for different hyperscale masking connectors.
For which we have a seperate `connectors` folder created.
The connectors like `mongo` or `delimeter` are written in "Python" but the base hyperscale code is in "Java".
Due to this we want to have separate pre-commit configs for each connector.

To overcome the default pre-commit config of hyperscale we have added the below in exclude, so that code inside connectors is skipped / excluded from default pre-commit checks
```
exclude: >
          (?x)^(
            .*.jar|
            .*.json|
            .*.mustache.*|
            .*.pem|
            .spotless.license.java|
            .*gradle-wrapper.properties|
            .*gradlew.*|
            .*lombok.config|
            common-lib/proto-generated-model/.*|
            common-lib/src/integration-test/resources/masking_otf_job_sync_export/masking.*|
            .*.key|
            eclipse_google_java_format.xml|
            connectors/.*|     <-------- this
          )$
```

Ref: https://github.com/delphix/hyperscale-masking

To run separate pre-commit for each repo we have used the nested_hooks code from qa runner repository and added the below in pre-commit config of hyperscale, as suggested by Jules.

Ref: https://github.com/delphix/qa-infra/blob/master/.pre-commit-config.yaml

```
  - repo: local
    hooks:
      - id: nested-hook
        name: nested-hook
        entry: nested_hook.py
        language: script
        verbose: true
        require_serial: true
        description: "pre-commit-hook to run other pre-commit-hooks inside connectors"
        args:
          - '-d=connectors/mongo'
          - '-d=connectors/delimiter'
```

On executing `pre-commit run`

##  Change No : 1 

Before setting `search_parent_directories=True`
We get the below error
```
copyright-check..........................................................Failed
- hook id: copyright-check
- exit code: 1

Traceback (most recent call last):
  File "/Users/rohit.shende/.cache/pre-commit/repo4v1rnaxr/py_env-python3.8/bin/copyright-checker", line 8, in <module>
    sys.exit(main())
  File "/Users/rohit.shende/.cache/pre-commit/repo4v1rnaxr/py_env-python3.8/lib/python3.8/site-packages/custom_hooks/copyright_checker.py", line 239, in main
    return copyright_checker(args.filenames, args.owner, update)
  File "/Users/rohit.shende/.cache/pre-commit/repo4v1rnaxr/py_env-python3.8/lib/python3.8/site-packages/custom_hooks/copyright_checker.py", line 207, in copyright_checker
    repo = git.Repo(os.getenv("GIT_REPO_DIR", "."))
  File "/Users/rohit.shende/.cache/pre-commit/repo4v1rnaxr/py_env-python3.8/lib/python3.8/site-packages/git/repo/base.py", line 265, in __init__
    raise InvalidGitRepositoryError(epath)
git.exc.InvalidGitRepositoryError: /Users/rohit.shende/Rohit/Projects/hyperscale-masking/connectors/delimiter
```

because the nested hook changes the current directory to `connectors/mongo` and then locks the directory, The copyright-checker tries to call `git diff` on the files and tries to set the 
```
repo = Repo('.')
```
Due to which it tries to find .git folder inside `connectors/mongo` (current working directory) and hence fails with a `InvalidGitRepositoryError`

## Solution No 1:
To resolve this `InvalidGitRepositoryError` we made a change in copyright-checker to set `search_parent_directories=True`

<b>Change:</b>
```
repo = git.Repo(".", search_parent_directories=True)
```

## Change No 2:
By default it uses relative path for each file while passing that file to `check_copyright` method.
That results in the following error:
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/rohit.shende/.cache/pre-commit/repol_14u1il/py_env-python3.8/bin/copyright-checker", line 8, in <module>
    sys.exit(main())
  File "/Users/rohit.shende/.cache/pre-commit/repol_14u1il/py_env-python3.8/lib/python3.8/site-packages/custom_hooks/copyright_checker.py", line 239, in main
    return copyright_checker(args.filenames, args.owner, update)
  File "/Users/rohit.shende/.cache/pre-commit/repol_14u1il/py_env-python3.8/lib/python3.8/site-packages/custom_hooks/copyright_checker.py", line 211, in copyright_checker
    result = check_copyright(filename, owner, update, repo,
  File "/Users/rohit.shende/.cache/pre-commit/repol_14u1il/py_env-python3.8/lib/python3.8/site-packages/custom_hooks/copyright_checker.py", line 171, in check_copyright
    if utils.get_changes(repo, filename) and curr_year != first_year:
  File "/Users/rohit.shende/.cache/pre-commit/repol_14u1il/py_env-python3.8/lib/python3.8/site-packages/custom_hooks/utils.py", line 19, in get_changes
    changes = repo.git.diff(["HEAD~", filename])
  File "/Users/rohit.shende/.cache/pre-commit/repol_14u1il/py_env-python3.8/lib/python3.8/site-packages/git/cmd.py", line 741, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
  File "/Users/rohit.shende/.cache/pre-commit/repol_14u1il/py_env-python3.8/lib/python3.8/site-packages/git/cmd.py", line 1315, in _call_process
    return self.execute(call, **exec_kwargs)
  File "/Users/rohit.shende/.cache/pre-commit/repol_14u1il/py_env-python3.8/lib/python3.8/site-packages/git/cmd.py", line 1109, in execute
    raise GitCommandError(redacted_command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git diff HEAD~ mongo-unload-service/container_conf/app_files/main.py
  stderr: 'fatal: ambiguous argument 'mongo-unload-service/container_conf/app_files/main.py': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]''

```

If we check the error above it is trying to use `git diff` with a relative path to the file
```
git diff HEAD~ mongo-unload-service/container_conf/app_files/main.py
```

This when tried manually on terminal Fails with the same error. 

## Solution No: 2

To solve this issue we can pass the absoulte path of the file to `check_copyright` method.
This will result in creation of the following command which will work:
```
git diff HEAD~ /Users/rohit.shende/Rohit/Projects/hyperscale-masking/mongo-unload-service/container_conf/app_files/main.py
```


# Final Test Run 

All `PASSED` for each nested hooks:

<img width="822" alt="image" src="https://github.com/jorgetomtz/pre-commit-hooks/assets/93119173/eb469a96-2374-4aa6-aae5-0c8439c5406b">

