### PR TITLE
copyright-checker should look at the most recent git timestamp

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,6 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-bugbear
-
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.1.1
     hooks:
@@ -32,6 +25,13 @@ repos:
     rev: 23.1.0
     hooks:
       - id: black
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-bugbear
 
   - repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "custom_hooks"
-version = "1.0.3"
+version = "1.0.4"
 description = "Custom pre-commit hooks"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/custom_hooks/copyright_checker.py
+++ b/src/custom_hooks/copyright_checker.py
@@ -205,11 +205,12 @@ def check_copyright(
         # If we know that the copyright might be out of date we can
         # check the last year and compare that with the current year.
         #
+        author_year = file_authored(repo, filename)
         should_check = False
-        if not file_authored(repo, filename):
+        if not author_year:
             should_check = True
             print(f"File is not yet in git: {filename}")
-        elif file_authored(repo, filename) == curr_year:
+        elif author_year == curr_year:
             should_check = True
             print(f"File was updated this year: {filename}")
         elif file_staged(repo, filename):

--- a/src/custom_hooks/copyright_checker.py
+++ b/src/custom_hooks/copyright_checker.py
@@ -55,9 +55,9 @@ def file_staged(repo: git.Repo, filename: str) -> bool:
     Return True if the file is currently staged in git, False
     otherwise
     """
-    staged_files = [
+    staged_files = {
         os.path.join(repo.working_dir, f.a_path) for f in repo.index.diff("HEAD")
-    ]
+    }
     return filename in staged_files
 
 

--- a/src/custom_hooks/copyright_checker.py
+++ b/src/custom_hooks/copyright_checker.py
@@ -11,7 +11,6 @@ import typing
 
 import git
 
-
 COPYRIGHT = "Copyright (c) {year} by {owner}. All rights reserved."
 
 HASH_ENDINGS = {
@@ -40,15 +39,25 @@ MD_ENDINGS = {"md"}
 STAR_ENDINGS = {"gradle", "groovy", "java", "js", "ts", "css"}
 
 
-def file_authored(repo, filename):
+def file_authored(repo: git.Repo, filename: str) -> int | None:
+    """
+    Return the year that the file was last modified in git or None if
+    it is not in the git history.
+    """
     updated_timestamp = repo.git.log("--format=%at", "-1", "--", filename)
     if not updated_timestamp:
         return None
     return datetime.datetime.utcfromtimestamp(int(updated_timestamp)).year
 
 
-def file_staged(repo, filename):
-    staged_files = [os.path.join(repo.working_dir, f.a_path) for f in repo.index.diff("HEAD")]
+def file_staged(repo: git.Repo, filename: str) -> bool:
+    """
+    Return True if the file is currently staged in git, False
+    otherwise
+    """
+    staged_files = [
+        os.path.join(repo.working_dir, f.a_path) for f in repo.index.diff("HEAD")
+    ]
     return filename in staged_files
 
 
@@ -219,10 +228,7 @@ def check_copyright(
                 )
             else:
                 # Copyright has a year range and is out-of-date
-                new_copyright = full_match.replace(
-                    str(second_year),
-                    f"{curr_year}"
-                )
+                new_copyright = full_match.replace(str(second_year), f"{curr_year}")
 
             if update:
                 print(f"Updating copyright: {filename}")

--- a/src/custom_hooks/copyright_checker.py
+++ b/src/custom_hooks/copyright_checker.py
@@ -11,7 +11,6 @@ import typing
 
 import git
 
-from custom_hooks import utils
 
 COPYRIGHT = "Copyright (c) {year} by {owner}. All rights reserved."
 
@@ -39,6 +38,18 @@ DASH_ENDINGS = {"lua"}
 MD_ENDINGS = {"md"}
 
 STAR_ENDINGS = {"gradle", "groovy", "java", "js", "ts", "css"}
+
+
+def file_authored(repo, filename):
+    updated_timestamp = repo.git.log("--format=%at", "-1", "--", filename)
+    if not updated_timestamp:
+        return None
+    return datetime.datetime.utcfromtimestamp(int(updated_timestamp)).year
+
+
+def file_staged(repo, filename):
+    staged_files = [os.path.join(repo.working_dir, f.a_path) for f in repo.index.diff("HEAD")]
+    return filename in staged_files
 
 
 def read_file(filename: str) -> str | None:
@@ -111,7 +122,7 @@ def get_index_after_special_lines(content: str) -> int:
 
 
 def insert_missing_copyright(
-    filename: str, content: str, year: str, owner: str
+    filename: str, content: str, year: int, owner: str
 ) -> None:
     """
     Insert missing copyright.
@@ -149,7 +160,7 @@ def content_head(content: str) -> str:
 
 
 def check_copyright(
-    filename: str, owner: str, update: bool, repo: git.Repo, curr_year: str
+    filename: str, owner: str, update: bool, repo: git.Repo, curr_year: int
 ) -> int:
     """
     Check the copyright of a file. Compose a basic copyright regex with
@@ -166,20 +177,53 @@ def check_copyright(
     )
     # Search the head of the content for copyright
     if m := copyright_rgx.search(content_head(content)):
+        #
+        # At this point we know the file has a copyright we just need
+        # to determine whether or not it is out of date and if so
+        # update it.
+        #
         full_match = m.group(0)
-        first_year, second_year = m.groups()
-        if utils.get_changes(repo, filename) and curr_year != first_year:
+        first_year = int(m.group(1))
+        second_year = int(m.group(2)[2:]) if m.group(2) else None
+        last_year = second_year or first_year
+
+        #
+        # We know that a file is a candidate to have an old copyright if:
+        #  - The file is not in git
+        #  - The file was updated in git this year
+        #  - The file is currently staged to be added to git
+        #
+        # If we know that the copyright might be out of date we can
+        # check the last year and compare that with the current year.
+        #
+        should_check = False
+        if not file_authored(repo, filename):
+            should_check = True
+            print(f"File is not yet in git: {filename}")
+        elif file_authored(repo, filename) == curr_year:
+            should_check = True
+            print(f"File was updated this year: {filename}")
+        elif file_staged(repo, filename):
+            should_check = True
+            print(f"File is staged to be committed: {filename}")
+
+        if should_check and last_year < curr_year:
+            #
+            # At this point we know that the copyright is out of date
+            #
             if second_year is None:
                 # Copyright only has one year and is out-of-date
                 new_copyright = full_match.replace(
-                    first_year, f"{first_year}, {curr_year}"
+                    str(first_year),
+                    f"{first_year}, {curr_year}",
                 )
-            elif not second_year.endswith(curr_year):
-                # Copyright has a year range and is out-of-date
-                new_copyright = full_match.replace(second_year, f", {curr_year}")
             else:
-                # Copyright is up-to-date
-                return 0
+                # Copyright has a year range and is out-of-date
+                new_copyright = full_match.replace(
+                    str(second_year),
+                    f"{curr_year}"
+                )
+
             if update:
                 print(f"Updating copyright: {filename}")
                 content = copyright_rgx.sub(new_copyright, content, 1)
@@ -205,7 +249,7 @@ def copyright_checker(filenames: list[str], owner: str, update: bool) -> int:
     """
     result = 0
     repo = git.Repo(".", search_parent_directories=True)
-    year = str(datetime.date.today().year)
+    year = datetime.date.today().year
     for filename in filenames:
         abs_filename = os.path.abspath(filename)
         result = check_copyright(abs_filename, owner, update, repo, year) or result

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,12 +7,14 @@ class FakeDiff:
     def __init__(self, a_path):
         self.a_path = a_path
 
+
 class FakeIndex:
     def __init__(self, diffs):
         self.diffs = diffs
 
     def diff(self, *args, **kwargs):
         return self.diffs
+
 
 class FakeGit:
     def __init__(self, changes, date):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,34 +2,52 @@ from __future__ import annotations
 
 import pytest
 
-CHANGES = """
-+Changes Found
-"""
 
+class FakeDiff:
+    def __init__(self, a_path):
+        self.a_path = a_path
+
+class FakeIndex:
+    def __init__(self, diffs):
+        self.diffs = diffs
+
+    def diff(self, *args, **kwargs):
+        return self.diffs
 
 class FakeGit:
-    def __init__(self, changes):
+    def __init__(self, changes, date):
         self.changes = changes
+        self.date = date
 
-    def diff(self, args):
+    def diff(self, *args, **kwargs):
         return self.changes
+
+    def log(self, *args, **kwargs):
+        return self.date
 
 
 class FakeGitRepo:
-    def __init__(self, changes):
-        self.git = FakeGit(changes)
+    def __init__(self, changes, date, working_dir, files):
+        self.git = FakeGit(changes, date)
+        self.index = FakeIndex([FakeDiff(f) for f in files])
+        self.working_dir = working_dir
+
+
+@pytest.fixture()
+def date():
+    return "1704321349"
+
+
+@pytest.fixture()
+def changes():
+    return "\n+Changes Found\n"
+
+
+@pytest.fixture()
+def files():
+    return ["CHANGELOG.md"]
 
 
 @pytest.fixture(autouse=True)
-def fake_git(mocker):
-    mocker.patch("git.Repo", return_value=FakeGitRepo(CHANGES))
-
-
-@pytest.fixture
-def fake_git_no_changes(mocker):
-    mocker.patch("git.Repo", return_value=FakeGitRepo(""))
-
-
-@pytest.fixture
-def fake_git_version_changes(mocker):
-    mocker.patch("git.Repo", return_value=FakeGitRepo("+version = 0.1.0"))
+def fake_git(mocker, date, changes, files, tmpdir):
+    mocker.patch("git.Repo", return_value=FakeGitRepo(changes, date, tmpdir, files))

--- a/test/test_check_version_bumped.py
+++ b/test/test_check_version_bumped.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from custom_hooks import check_version_bumped
-
 import pytest
 
+from custom_hooks import check_version_bumped
 
-@pytest.mark.parametrize(
-    "changes", [""]
-)
+
+@pytest.mark.parametrize("changes", [""])
 def test_no_bump(tmpdir, changes):
     d = tmpdir / "d"
     d.mkdir()
@@ -30,9 +28,7 @@ def test_no_bump_and_required(capsys, tmpdir):
     assert f"Version bumped required in {f}" in cap.out
 
 
-@pytest.mark.parametrize(
-    "changes", ["+version = 0.1.0"]
-)
+@pytest.mark.parametrize("changes", ["+version = 0.1.0"])
 def test_bump_and_required(tmpdir, changes):
     d = tmpdir / "d"
     d.mkdir()

--- a/test/test_check_version_bumped.py
+++ b/test/test_check_version_bumped.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 from custom_hooks import check_version_bumped
 
+import pytest
 
-def test_no_bump(tmpdir, fake_git_no_changes):
+
+@pytest.mark.parametrize(
+    "changes", [""]
+)
+def test_no_bump(tmpdir, changes):
     d = tmpdir / "d"
     d.mkdir()
     f = d / "setup.cfg"
@@ -25,7 +30,10 @@ def test_no_bump_and_required(capsys, tmpdir):
     assert f"Version bumped required in {f}" in cap.out
 
 
-def test_bump_and_required(capsys, tmpdir, fake_git_version_changes):
+@pytest.mark.parametrize(
+    "changes", ["+version = 0.1.0"]
+)
+def test_bump_and_required(tmpdir, changes):
     d = tmpdir / "d"
     d.mkdir()
     f = d / "pyproject.toml"

--- a/test/test_copyright_checker.py
+++ b/test/test_copyright_checker.py
@@ -116,9 +116,7 @@ def test_multiple_one_new_one_old_copyright_py(capsys, tmpdir):
     assert f"Updating copyright: {f}" in cap.out
 
 
-@pytest.mark.parametrize(
-    "date,changes", [("1", "")]
-)
+@pytest.mark.parametrize("date,changes", [("1", "")])
 def test_old_copyright_py_no_changes(tmpdir, date, changes):
     f = tmpdir / "a.py"
     t = "#\n# Copyright (c) 2000 by fake. All rights reserved.\n#\n"

--- a/test/test_copyright_checker.py
+++ b/test/test_copyright_checker.py
@@ -116,7 +116,10 @@ def test_multiple_one_new_one_old_copyright_py(capsys, tmpdir):
     assert f"Updating copyright: {f}" in cap.out
 
 
-def test_old_copyright_py_no_changes(tmpdir, fake_git_no_changes):
+@pytest.mark.parametrize(
+    "date,changes", [("1", "")]
+)
+def test_old_copyright_py_no_changes(tmpdir, date, changes):
     f = tmpdir / "a.py"
     t = "#\n# Copyright (c) 2000 by fake. All rights reserved.\n#\n"
     f.write(t)


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

I've noticed that the copyright checker will only check files that
have been changed between the current commit and upstream. Although
this works well in the common case it can lead to issues if:
 - a file was modified in the current year
 - was pushed upstream without bumping the version
 
this means that:
```
$ pre-commit run -a copyright-check
```

will not catch issues in files that were already pushed

</details>

<details open>
<summary><h2> Solution </h2></summary>

Instead of checking that a file is different between the local commit
and upstream we should check a file to see when it was last updated in
git. A file is considered new if it was updated in the current
year. This can fall into a few categories:
 - A file is not yet in git but being checked
 - A file is staged to be added to git but is not yet in a "new" commit
 - A file was changed in a commit that happened in the current year

</details>


<details open>
<summary><h2> Testing Done </h2></summary>

All unit tests pass. I've also linked to this repository locally and
validated that `pre-commit run -a copyright` updated files that were
changed but whose copyright had not been updated.

</details>
